### PR TITLE
Add unit tests for makeZip

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -51,14 +51,15 @@ app.get(
   '/export-copy/:sku',
   async (req: Request, res: Response): Promise<void> => {
     const { sku } = req.params;
+    const rootDir = join(__dirname, './out');
     const options = {
-      root: join(__dirname, './out'),
+      root: rootDir,
       dotfiles: 'deny',
     };
     // `sku` comes with .zip at the end, which we must remove
     const cleanSku = parse(sku).name;
     await Ledger.getDoc(cleanSku, 'id')
-      .then(r => Store.makeZip(r))
+      .then(r => Store.makeZip(r, rootDir, rootDir))
       .then(() =>
         res
           .set(`Content-Type`, `application/octet-stream`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "archiver": "^5.3.0",
         "autoprefixer": "^10.3.1",
         "jest": "^27.0.6",
+        "node-stream-zip": "^1.14.0",
         "supertest": "^6.1.6",
         "ts-jest": "^27.0.5",
         "ts-mock-imports": "^1.3.7",
@@ -4690,6 +4691,19 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
       "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
       "dev": true
+    },
+    "node_modules/node-stream-zip": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.14.0.tgz",
+      "integrity": "sha512-SKXyiBy9DBemsPHf/piHT00Y+iPK+zwru1G6+8UdOBzITnmmPMHYBMV6M1znyzyhDhUFQW0HEmbGiPqtp51M6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/antelle"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -10269,6 +10283,12 @@
       "version": "1.1.75",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
       "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "dev": true
+    },
+    "node-stream-zip": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.14.0.tgz",
+      "integrity": "sha512-SKXyiBy9DBemsPHf/piHT00Y+iPK+zwru1G6+8UdOBzITnmmPMHYBMV6M1znyzyhDhUFQW0HEmbGiPqtp51M6Q==",
       "dev": true
     },
     "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "archiver": "^5.3.0",
     "autoprefixer": "^10.3.1",
     "jest": "^27.0.6",
+    "node-stream-zip": "^1.14.0",
     "supertest": "^6.1.6",
     "ts-jest": "^27.0.5",
     "ts-mock-imports": "^1.3.7",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -119,14 +119,24 @@ export const makeZip = (
       resolve();
     });
     zip
-      .append(fs.createReadStream(`${bundleRootDirectory}/${screenshot}`), {
-        name: screenshot,
-      })
-      .append(fs.createReadStream(`${bundleRootDirectory}/${one_file}`), {
-        name: one_file,
-      })
+      .append(
+        fs
+          .createReadStream(`${bundleRootDirectory}/${screenshot}`)
+          .on('error', reject),
+        {
+          name: screenshot,
+        }
+      )
+      .append(
+        fs
+          .createReadStream(`${bundleRootDirectory}/${one_file}`)
+          .on('error', reject),
+        {
+          name: one_file,
+        }
+      )
       .append(sidecarTextFile, { name: `about-this-export.txt` })
-      .on('error', err => reject(err))
+      .on('error', reject)
       .pipe(stream);
     zip.finalize();
   });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import { join } from 'path';
 import 'archiver';
 import { mkdir } from 'fs/promises';
 import { makeHash } from '../helpers';
@@ -96,7 +95,7 @@ Files included:
 export const makeZip = (
   r: Record.Record,
   bundleRootDirectory: string,
-  outDirectory: fs.PathLike
+  outDirectory: string
 ): Promise<void> => {
   const b = r.bundle;
   const zip = archiver('zip', { zlib: { level: 0 } });

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -152,4 +152,33 @@ describe('makeZip', () => {
     });
     z.close();
   });
+
+  it('should return a rejected promise when a file is missing on disk', async () => {
+    const oneFileHash = 'this-is-the-file';
+    const screenshotHash = 'pretty-picture';
+
+    // simulate a missing file
+    // fs.writeFileSync(path.join(bundleRootDir, `${oneFileHash}.html`), 'jeej');
+    fs.writeFileSync(path.join(bundleRootDir, `${screenshotHash}.png`), 'tuut');
+
+    const record: Record = {
+      data: {
+        title: 'Non Stop Nyan Cat',
+        url: 'http://www.nyan.cat/',
+      },
+      annotations: {
+        description: 'A cat farting an infinite rainbow',
+      },
+      bundle: [
+        { kind: 'one_file', hash: oneFileHash },
+        { kind: 'screenshot', hash: screenshotHash },
+      ],
+    };
+
+    await Store.makeZip(record, bundleRootDir, outDir)
+      .then(() => {
+        throw new Error('hello error, bad luck');
+      })
+      .catch(err => console.log(`Error: ${err}`));
+  });
 });

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import Zip from 'node-stream-zip';
 
 import type { Bundle } from '../types/Bundle';
 import type { Record } from '../types/Record';
@@ -137,7 +138,18 @@ describe('makeZip', () => {
 
     await Store.makeZip(record, bundleRootDir, outDir);
 
-    // check for the zip's existence (would throw if it didn't exist)
-    fs.statSync(path.join(outDir, `${id(record.bundle)}.zip`));
+    const zipPath = path.join(outDir, `${id(record.bundle)}.zip`);
+
+    // check for the zip's existence and contents
+    // TODO: for this test to be complete, we should also check the files
+    // contents themselves.
+    const z = new Zip.async({ file: zipPath });
+    const entries = await z.entries();
+    expect(entries).toEqual({
+      [`${oneFileHash}.html`]: expect.any(Object),
+      [`${screenshotHash}.png`]: expect.any(Object),
+      'about-this-export.txt': expect.any(Object),
+    });
+    z.close();
   });
 });


### PR DESCRIPTION
This adds two unit tests for makeZip:
- good scenario
- missing files scenario

makeZip is refactored to take in/out directory as parameters.