### PR TITLE
Refactor file extension handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
       "email": "niko@niko.io"
     }
   ],
-  "version": "0.8.0",
+  "version": "0.9.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/digitalevidencetoolkit/deptoolkit"

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -2,17 +2,15 @@ import * as fs from 'fs';
 import * as path from 'path';
 import Zip from 'node-stream-zip';
 
-import type { Bundle } from '../types/Bundle';
-import type { Record } from '../types/Record';
-import type { File } from '../types/File';
+import * as Bundle from '../types/Bundle';
+import * as Record from '../types/Record';
+import * as File from '../types/File';
 
 import * as Store from './index';
-import { fileName } from '../types/File';
-import { id } from '../types/Bundle';
 
 describe('generateAboutString', () => {
   it('should throw if the record is missing the screenshot or one_file', () => {
-    const bundles: Bundle[] = [
+    const bundles: Bundle.Bundle[] = [
       [],
       [{ hash: 'jeej', kind: 'one_file' }],
       [{ hash: 'tuut', kind: 'screenshot' }],
@@ -37,8 +35,11 @@ describe('generateAboutString', () => {
   it('should generate a string describing the given bundle', () => {
     const title = 'Win big money in no time thanks to this one simple trick';
     const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
-    const oneFile: File = { hash: 'this-is-the-file', kind: 'one_file' };
-    const screenshot: File = { hash: 'pretty-picture', kind: 'screenshot' };
+    const oneFile: File.File = { hash: 'this-is-the-file', kind: 'one_file' };
+    const screenshot: File.File = {
+      hash: 'pretty-picture',
+      kind: 'screenshot',
+    };
     const ogNow = Date.now;
     Date.now = () => 42;
 
@@ -61,8 +62,8 @@ ${title}
 ${url}
 
 Files included:
-  ${fileName(screenshot)}
-  ${fileName(oneFile)}`;
+  ${File.fileName(screenshot)}
+  ${File.fileName(oneFile)}`;
 
     expect(result).toEqual(expected);
 
@@ -86,7 +87,7 @@ describe('makeZip', () => {
   });
 
   it('should reject if the record is missing the screenshot or one_file', () => {
-    const bundles: Bundle[] = [
+    const bundles: Bundle.Bundle[] = [
       [],
       [{ hash: 'jeej', kind: 'one_file' }],
       [{ hash: 'tuut', kind: 'screenshot' }],
@@ -115,15 +116,18 @@ describe('makeZip', () => {
   });
 
   it('should produce a zip of the given record, in the correct location', async () => {
-    const oneFile: File = { hash: 'this-is-the-file', kind: 'one_file' };
-    const screenshot: File = { hash: 'pretty-picture', kind: 'screenshot' };
-    const oneFileName = fileName(oneFile);
-    const screenshotName = fileName(screenshot);
+    const oneFile: File.File = { hash: 'this-is-the-file', kind: 'one_file' };
+    const screenshot: File.File = {
+      hash: 'pretty-picture',
+      kind: 'screenshot',
+    };
+    const oneFileName = File.fileName(oneFile);
+    const screenshotName = File.fileName(screenshot);
 
     fs.writeFileSync(path.join(bundleRootDir, oneFileName), 'jeej');
     fs.writeFileSync(path.join(bundleRootDir, screenshotName), 'tuut');
 
-    const record: Record = {
+    const record: Record.Record = {
       data: {
         title: 'Non Stop Nyan Cat',
         url: 'http://www.nyan.cat/',
@@ -136,7 +140,7 @@ describe('makeZip', () => {
 
     await Store.makeZip(record, bundleRootDir, outDir);
 
-    const zipPath = path.join(outDir, `${id(record.bundle)}.zip`);
+    const zipPath = path.join(outDir, `${Bundle.id(record.bundle)}.zip`);
 
     // check for the zip's existence and contents
     // TODO: for this test to be complete, we should also check the files
@@ -152,16 +156,18 @@ describe('makeZip', () => {
   });
 
   it('should return a rejected promise when a file is missing on disk', async () => {
-    const oneFile: File = { hash: 'this-is-the-file', kind: 'one_file' };
-    const screenshot: File = { hash: 'pretty-picture', kind: 'screenshot' };
-    const oneFileName = fileName(oneFile);
-    const screenshotName = fileName(screenshot);
+    const oneFile: File.File = { hash: 'this-is-the-file', kind: 'one_file' };
+    const screenshot: File.File = {
+      hash: 'pretty-picture',
+      kind: 'screenshot',
+    };
+    const screenshotName = File.fileName(screenshot);
 
     // simulate a missing file
     // fs.writeFileSync(path.join(bundleRootDir, oneFileName), 'jeej');
     fs.writeFileSync(path.join(bundleRootDir, screenshotName), 'tuut');
 
-    const record: Record = {
+    const record: Record.Record = {
       data: {
         title: 'Non Stop Nyan Cat',
         url: 'http://www.nyan.cat/',

--- a/src/types/File.test.ts
+++ b/src/types/File.test.ts
@@ -1,0 +1,26 @@
+import * as File from './File';
+
+describe('id', () => {
+  it('should return the file hash', () => {
+    const hash = 'I should have been a pair of ragged claws';
+    expect(File.id({ kind: 'one_file', hash })).toBe(hash);
+  });
+});
+
+describe('fileName', () => {
+  it('should generate the file name by adding the correct extention to the hash', () => {
+    const cases: Array<File.File & { expected: string }> = [
+      { hash: 'The gate is straight', kind: 'one_file', expected: 'html' },
+      { hash: 'Deep and wide', kind: 'screenshot', expected: 'png' },
+      {
+        hash: 'Break on through to the other side',
+        kind: 'screenshot_thumbnail',
+        expected: 'png',
+      },
+    ];
+
+    cases.forEach(c => {
+      expect(File.fileName(c)).toBe(`${c.hash}.${c.expected}`);
+    });
+  });
+});

--- a/src/types/File.ts
+++ b/src/types/File.ts
@@ -15,7 +15,7 @@ export const id = (a: File) => a.hash;
 
 /**
  * Generates a complete filename from a given file.
- * @returns A complete filename, with the correct extention according to the
+ * @returns A complete filename, with the correct extension according to the
  * file's kind.
  */
 export const fileName: (f: File) => string = ({ kind, hash }) =>

--- a/src/types/File.ts
+++ b/src/types/File.ts
@@ -12,3 +12,11 @@ export type newFile = { kind: Process; data: Buffer | string };
  * @returns string
  */
 export const id = (a: File) => a.hash;
+
+/**
+ * Generates a complete filename from a given file.
+ * @returns A complete filename, with the correct extention according to the
+ * file's kind.
+ */
+export const fileName: (f: File) => string = ({ kind, hash }) =>
+  `${hash}.${kind === 'one_file' ? 'html' : 'png'}`;


### PR DESCRIPTION
- add a util generating a file name from a `File` object. This factorizes the logic choosing the file's extention
- add unit tests on this
- use this util where relevant