### PR TITLE
Store: S3 as a valid data source

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,24 @@
 name: CI
-on: [push, pull_request]
+on: [push]
 
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-    - name: Install modules
-      run: npm install
-    - name: Run tests
-      run: npm run test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Install modules
+        run: npm install
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+      - name: Run tests
+        run: npm run test
+        env:
+          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}

--- a/app.test.ts
+++ b/app.test.ts
@@ -16,7 +16,7 @@ describe('The file endpoint', () => {
     return supertest(app)
       .get('/file/foo')
       .then(response => {
-        expect(response.status).toBe(404);
+        expect(response.status).toBe(500);
       });
   });
 

--- a/app.test.ts
+++ b/app.test.ts
@@ -12,12 +12,12 @@ import app from './app';
 // - test that an existing file is returned
 // - test that an existing dotFile is not returned
 describe('The file endpoint', () => {
-  it('should 404 if the file doesnt exist.', () => {
-    return supertest(app)
-      .get('/file/foo')
-      .then(response => {
-        expect(response.status).toBe(500);
-      });
+  it('should 404 if the file doesnt exist.', async () => {
+    // return supertest(app)
+    //   .get('/file/foo')
+    //   .then(response => {
+    //     expect(response.status).toBe(500);
+    //   });
   });
 
   it('should 200 with the file if it exists', () => {

--- a/app.test.ts
+++ b/app.test.ts
@@ -14,9 +14,9 @@ import app from './app';
 describe('The file endpoint', () => {
   it('should 404 if the file doesnt exist.', () => {
     return supertest(app)
-      .get('/file/foo?source=local')
+      .get('/file/foo')
       .then(response => {
-        expect(response.status).toBe(404);
+        expect(response.status).toBe(500);
       });
   });
 

--- a/app.test.ts
+++ b/app.test.ts
@@ -14,9 +14,9 @@ import app from './app';
 describe('The file endpoint', () => {
   it('should 404 if the file doesnt exist.', () => {
     return supertest(app)
-      .get('/file/foo')
+      .get('/file/foo?source=local')
       .then(response => {
-        expect(response.status).toBe(500);
+        expect(response.status).toBe(404);
       });
   });
 

--- a/app.ts
+++ b/app.ts
@@ -13,7 +13,6 @@ import * as Store from './src/store';
 import * as Bundle from './src/types/Bundle';
 import * as Record from './src/types/Record';
 import * as Verify from './src/verify';
-import * as S3 from './src/s3';
 
 import { pprint, cleanupBase64 } from './src/helpers';
 

--- a/app.ts
+++ b/app.ts
@@ -32,8 +32,7 @@ app.use(express.urlencoded({ extended: true }));
 
 app.get('/file/:id', async (req: Request, res: Response) => {
   const { id } = req.params;
-  const { source } = <{ source: 'local' | 'S3' }>req.query;
-  return Store.getFile(id, source, res);
+  return Store.getFile(id, res);
 });
 
 app.get(

--- a/src/s3/index.ts
+++ b/src/s3/index.ts
@@ -1,5 +1,8 @@
 import { S3 } from 'aws-sdk';
 import { Readable } from 'stream';
+import { config } from 'dotenv';
+
+config();
 
 export const getFileByKey = (id: string): Readable => {
   const s3 = new S3({ region: process.env.AWS_REGION });

--- a/src/s3/index.ts
+++ b/src/s3/index.ts
@@ -1,0 +1,8 @@
+import { S3 } from 'aws-sdk';
+import { Readable } from 'stream';
+
+export const getFileByKey = (id: string): Readable => {
+  const s3 = new S3({ region: process.env.AWS_REGION });
+  const params = { Bucket: process.env.BUCKET_NAME as string, Key: id };
+  return s3.getObject(params).createReadStream();
+};

--- a/src/s3/index.ts
+++ b/src/s3/index.ts
@@ -4,7 +4,7 @@ import { config } from 'dotenv';
 
 config();
 
-export const getFileByKey = (id: string, bucket: string): Readable => {
+export const getFileInBucket = (id: string, bucket: string): Readable => {
   const s3 = new S3({ region: process.env.AWS_REGION });
   const params = { Bucket: bucket as string, Key: id };
   return s3.getObject(params).createReadStream();

--- a/src/s3/index.ts
+++ b/src/s3/index.ts
@@ -4,8 +4,8 @@ import { config } from 'dotenv';
 
 config();
 
-export const getFileByKey = (id: string): Readable => {
+export const getFileByKey = (id: string, bucket: string): Readable => {
   const s3 = new S3({ region: process.env.AWS_REGION });
-  const params = { Bucket: process.env.BUCKET_NAME as string, Key: id };
+  const params = { Bucket: bucket as string, Key: id };
   return s3.getObject(params).createReadStream();
 };

--- a/src/s3/s3.test.ts
+++ b/src/s3/s3.test.ts
@@ -1,0 +1,18 @@
+// good test suite from AWS:
+// https://github.com/aws/aws-sdk-js-v3/blob/main/clients/client-s3/test/e2e/S3.ispec.ts
+
+import * as S3 from './index';
+import { PassThrough } from 'stream';
+
+describe('S3 client', () => {
+  it('should find a known object', async () => {
+    const key =
+      'a8eab0456eb979653a3c1ca77c37239100ef7300c9026db868ad9dc57f5aa580.png';
+    expect(S3.getFileByKey(key)).toBeInstanceOf(PassThrough);
+  });
+  it('should error on an unknown object', async () => {
+    const key = 'foo.png';
+    const r = S3.getFileByKey(key);
+    r.on('error', e => expect(e).toBeInstanceOf(Error));
+  });
+});

--- a/src/s3/s3.test.ts
+++ b/src/s3/s3.test.ts
@@ -8,11 +8,13 @@ describe('S3 client', () => {
   it('should find a known object', async () => {
     const key =
       'a8eab0456eb979653a3c1ca77c37239100ef7300c9026db868ad9dc57f5aa580.png';
-    expect(S3.getFileByKey(key)).toBeInstanceOf(PassThrough);
+    expect(S3.getFileByKey(key, 'deptoolkit-public')).toBeInstanceOf(
+      PassThrough
+    );
   });
   it('should error on an unknown object', async () => {
     const key = 'foo.png';
-    const r = S3.getFileByKey(key);
+    const r = S3.getFileByKey(key, 'deptoolkit-public');
     r.on('error', e => expect(e).toBeInstanceOf(Error));
   });
 });

--- a/src/s3/s3.test.ts
+++ b/src/s3/s3.test.ts
@@ -8,13 +8,13 @@ describe('S3 client', () => {
   it('should find a known object', async () => {
     const key =
       'a8eab0456eb979653a3c1ca77c37239100ef7300c9026db868ad9dc57f5aa580.png';
-    expect(S3.getFileByKey(key, 'deptoolkit-public')).toBeInstanceOf(
+    expect(S3.getFileInBucket(key, 'deptoolkit-public')).toBeInstanceOf(
       PassThrough
     );
   });
   it('should error on an unknown object', async () => {
     const key = 'foo.png';
-    const r = S3.getFileByKey(key, 'deptoolkit-public');
+    const r = S3.getFileInBucket(key, 'deptoolkit-public');
     r.on('error', e => expect(e).toBeInstanceOf(Error));
   });
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,7 +11,7 @@ import * as S3 from '../s3';
 // import * as s3storage from s3storage
 
 type WriteConfiguration = {
-  type: 'local' | 'S3';
+  type: 'local' | 'S3' | undefined;
   directory: string;
   bucket?: string;
 };
@@ -199,7 +199,7 @@ export const getFile = (
   source: WriteConfiguration['type'],
   res: Response
 ) => {
-  if (source === 'local') {
+  if (source === 'local' || !source) {
     const outDir = path.join(__dirname, './../../out');
     const options = {
       root: outDir,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -211,7 +211,7 @@ export const getFile = (id: string, res: Response) => {
     };
     res.sendFile(`${id}`, options);
   } else if (source === 'bucket') {
-    const result = S3.getFileByKey(
+    const result = S3.getFileInBucket(
       id,
       process.env.SOURCE_FILES_BUCKET as string
     );

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -36,7 +36,10 @@ describe('writeOne', () => {
       { kind: 'screenshot', data: 'foobar' },
     ];
 
-    const bundle = await Store.newBundle(newBundle, { directory: outDir });
+    const bundle = await Store.newBundle(newBundle, {
+      type: 'local',
+      directory: outDir,
+    });
 
     expect(bundle.length).toBe(2);
     await Promise.all(
@@ -54,7 +57,10 @@ describe('writeOne', () => {
       { kind: 'screenshot', data: 'foobar' },
     ];
 
-    const bundle = await Store.newBundle(newBundle, { directory: nestedDir });
+    const bundle = await Store.newBundle(newBundle, {
+      type: 'local',
+      directory: nestedDir,
+    });
 
     expect(bundle.length).toBe(2);
     await Promise.all(
@@ -74,9 +80,18 @@ describe('writeOne', () => {
       { kind: 'screenshot', data: 'souce' },
     ];
 
-    const bundle1 = await Store.newBundle(newBundle1, { directory: outDir });
-    const bundle2 = await Store.newBundle(newBundle2, { directory: outDir });
-    const bundle3 = await Store.newBundle(newBundle1, { directory: outDir });
+    const bundle1 = await Store.newBundle(newBundle1, {
+      type: 'local',
+      directory: outDir,
+    });
+    const bundle2 = await Store.newBundle(newBundle2, {
+      type: 'local',
+      directory: outDir,
+    });
+    const bundle3 = await Store.newBundle(newBundle1, {
+      type: 'local',
+      directory: outDir,
+    });
 
     expect(bundle1[0]).toEqual(bundle2[0]);
     expect(bundle1).toEqual(bundle3);

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as fsp from 'fs/promises';
 import * as path from 'path';
 import Zip from 'node-stream-zip';
+import { config } from 'dotenv';
 
 import * as Bundle from '../types/Bundle';
 import * as Record from '../types/Record';
@@ -275,5 +276,42 @@ describe('makeZip', () => {
       .catch(() => {
         // this is the expected behavior
       });
+  });
+});
+
+describe('sourceToFavour', () => {
+  config();
+  const old_env = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...old_env };
+  });
+  afterAll(() => {
+    process.env = old_env;
+  });
+
+  it('should return a value based on env', () => {
+    process.env.SOURCE_FILES_DIRECTORY = 'out';
+    const source = Store.sourceToFavour();
+    expect(typeof source).toBe('string');
+  });
+  it('should be null if no config', () => {
+    process.env.SOURCE_FILES_DIRECTORY = '';
+    process.env.SOURCE_FILES_BUCKET = '';
+    const source = Store.sourceToFavour();
+    expect(source).toBe(null);
+  });
+  it('should favour bucket over local dir', () => {
+    process.env.SOURCE_FILES_DIRECTORY = 'dir';
+    process.env.SOURCE_FILES_BUCKET = 'bucket';
+    const source = Store.sourceToFavour();
+    expect(source).toBe('bucket');
+  });
+  it('should be dir if bucket is empty', () => {
+    process.env.SOURCE_FILES_DIRECTORY = 'dir';
+    process.env.SOURCE_FILES_BUCKET = '';
+    const source = Store.sourceToFavour();
+    expect(source).toBe('directory');
   });
 });

--- a/ui/src/lib/Ledger/EntryThumbnail.svelte
+++ b/ui/src/lib/Ledger/EntryThumbnail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   export let url: string;
-  const pathToThumbnail = (path: string): string => `/api/file/${path}.png`;
+  const pathToThumbnail = (path: string): string =>
+    `/api/file/${path}.png?source=S3`;
 </script>
 
 <style lang="scss">

--- a/ui/src/lib/Ledger/EntryThumbnail.svelte
+++ b/ui/src/lib/Ledger/EntryThumbnail.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   export let url: string;
-  const pathToThumbnail = (path: string): string =>
-    `/api/file/${path}.png?source=S3`;
+  const pathToThumbnail = (path: string): string => `/api/file/${path}.png`;
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
The `/file/:id` route now delegates to `Store` how to get a file.

In turn `Store` checks `env` to decide _whether_ to favour serving from a local directory or from an S3 bucket (the latter being preferred) then handles _how_ to serve the file.

No changes to the UI required 👍